### PR TITLE
Update explanation.tex

### DIFF
--- a/Examples/src/FloatingPoint/FPFailure/explanation.tex
+++ b/Examples/src/FloatingPoint/FPFailure/explanation.tex
@@ -45,7 +45,7 @@ We define a sequence $x_n,\, n=0,1,\ldots$ as
 \]
     It can be easily found, by looking at the roots of the polynomial
     \[
-    x^3-111+1130x^2-3000,
+    x^3-111x^2+1130x-3000,
     \]
     that if the sequence converges it converges necessarily to either
     $5$, $6$, or $100$.


### PR DESCRIPTION
Possible mistake in the polynomial reported in the explanation of FPFailure. The previous reported polynomial (x^3-111+1130x^2-3000) does not have 5, 6 or 100 as roots. The updated polynomial was obtained by setting x_{n+1} = x_n = x_{n-1} = x, obtaining x = 111-1130/x+3000/x^2 and then multiplying both sides by x^2 and reordering factors.